### PR TITLE
fix imports

### DIFF
--- a/go-pool/rpc/rpc.go
+++ b/go-pool/rpc/rpc.go
@@ -11,7 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"../pool"
+	"github.com/sammy007/monero-stratum/go-pool/pool"
 )
 
 type RPCClient struct {

--- a/go-pool/stratum/api.go
+++ b/go-pool/stratum/api.go
@@ -6,8 +6,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"../rpc"
-	"../util"
+	"github.com/sammy007/monero-stratum/go-pool/rpc"
+	"github.com/sammy007/monero-stratum/go-pool/util"
 )
 
 func (s *StratumServer) StatsIndex(w http.ResponseWriter, r *http.Request) {

--- a/go-pool/stratum/blocks.go
+++ b/go-pool/stratum/blocks.go
@@ -6,7 +6,7 @@ import (
 	"encoding/hex"
 	"log"
 
-	"../../cnutil"
+	"github.com/sammy007/monero-stratum/cnutil"
 )
 
 type BlockTemplate struct {

--- a/go-pool/stratum/handlers.go
+++ b/go-pool/stratum/handlers.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"sync/atomic"
 
-	"../util"
+	"github.com/sammy007/monero-stratum/go-pool/util"
 )
 
 var noncePattern *regexp.Regexp

--- a/go-pool/stratum/miner.go
+++ b/go-pool/stratum/miner.go
@@ -10,9 +10,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"../../cnutil"
-	"../../hashing"
-	"../util"
+	"github.com/sammy007/monero-stratum/cnutil"
+	"github.com/sammy007/monero-stratum/hashing"
+	"github.com/sammy007/monero-stratum/go-pool/util"
 )
 
 type Job struct {

--- a/go-pool/stratum/stratum.go
+++ b/go-pool/stratum/stratum.go
@@ -12,9 +12,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"../pool"
-	"../rpc"
-	"../util"
+	"github.com/sammy007/monero-stratum/go-pool/pool"
+	"github.com/sammy007/monero-stratumgo-pool/rpc"
+	"github.com/sammy007/monero-stratum/go-pool/util"
 )
 
 type StratumServer struct {

--- a/go-pool/stratum/stratum.go
+++ b/go-pool/stratum/stratum.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/sammy007/monero-stratum/go-pool/pool"
-	"github.com/sammy007/monero-stratumgo-pool/rpc"
+	"github.com/sammy007/monero-stratum/go-pool/rpc"
 	"github.com/sammy007/monero-stratum/go-pool/util"
 )
 

--- a/go-pool/util/util.go
+++ b/go-pool/util/util.go
@@ -6,7 +6,7 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"../../cnutil"
+	"github.com/sammy007/monero-stratum/cnutil"
 )
 
 var Diff1 = StringToBig("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")

--- a/main.go
+++ b/main.go
@@ -10,8 +10,8 @@ import (
 	"runtime"
 	"time"
 
-	"./go-pool/pool"
-	"./go-pool/stratum"
+	"github.com/sammy007/monero-stratum/go-pool/pool"
+	"github.com/sammy007/monero-stratum/go-pool/stratum"
 
 	"github.com/goji/httpauth"
 	"github.com/gorilla/mux"


### PR DESCRIPTION
The relative import paths are known as bad practice as it breaks several Go tools.  This  also addresses the latest comment from https://github.com/sammy007/monero-stratum/issues/17 