### PR TITLE
[feature] save found blocks and round effort across runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ mainnet.json
 
 /build/_workspace/
 /build/bin/
+.idea

--- a/README.md
+++ b/README.md
@@ -146,11 +146,18 @@ Configuration is self-describing, just copy *config.example.json* to *config.jso
       "port": 18081,
       "timeout": "10s"
     }
-  ]
+  ],
+  
+  "statsDir": "stats"
 }
 ```
 
 You must use `anything.WorkerID` as username in your miner. Either disable address validation or use `<address>.WorkerID` as username. If there is no workerID specified your rig stats will be merged under `0` worker. If mining software contains dev fee rounds its stats will usually appear under `0` worker. This stratum acts like your own pool, the only exception is that you will get rewarded only after block found, shares only used for stats.
+
+## Stats
+Blocks found and round progress will be saved across runs in `$statsDir/stats.json` if you have enabled them by setting 
+`statsDir` in your `config.json`. You can also choose the interval (seconds) that stats are collected with by setting 
+`statsInterval`. The default is 5 seconds. 
 
 ### Donations
 

--- a/config.example.json
+++ b/config.example.json
@@ -58,5 +58,6 @@
 	"newrelicEnabled": false,
 	"newrelicName": "MyStratum",
 	"newrelicKey": "SECRET_KEY",
-	"newrelicVerbose": false
+	"newrelicVerbose": false,
+	"statsDir": "stats"
 }

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -17,6 +17,8 @@ type Config struct {
 	NewrelicKey             string     `json:"newrelicKey"`
 	NewrelicVerbose         bool       `json:"newrelicVerbose"`
 	NewrelicEnabled         bool       `json:"newrelicEnabled"`
+	StatsDir         		string     `json:"statsDir"`
+	StatsInterval			int		   `json:"statsInterval"`
 }
 
 type Stratum struct {

--- a/util/util.go
+++ b/util/util.go
@@ -2,7 +2,11 @@ package util
 
 import (
 	"encoding/hex"
+	"encoding/json"
+	"io/ioutil"
+	"log"
 	"math/big"
+	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -60,4 +64,42 @@ func reverse(src []byte) []byte {
 		dst[len(src)-i] = src[i-1]
 	}
 	return dst
+}
+
+// load any JSON file into a struct and return it
+func LoadJson(filename string) interface{} {
+	var s interface{}
+	data, err := ioutil.ReadFile(filename)
+	if err == nil {
+		// yuk.. what am I missing here...?
+		decoder := json.NewDecoder(strings.NewReader(string(data)))
+
+		// we have to set UseNumber to avoid getting float64s for all our timestamps, etc
+		decoder.UseNumber()
+		err := decoder.Decode(&s)
+
+		if err != nil {
+			log.Println("parsing stats file", err.Error())
+		}
+
+	} else {
+		log.Println("opening json file", err.Error())
+	}
+
+	return s
+
+}
+
+// save any Struct to a JSON file
+func SaveJson(filename string, s interface{}) {
+	jsonData, err := json.Marshal(s)
+	if err == nil {
+		err = ioutil.WriteFile(filename, []byte(jsonData), 0644)
+		if err != nil {
+			log.Println(err)
+		}
+	} else {
+		log.Println(err)
+	}
+
 }


### PR DESCRIPTION
Thanks for making this program, I added support for saving stats between runs. Also thinking of maybe logging timeseries data of historical hash rates (RRD?) - interested?

~~~
If `statsDir` is set in the config file, create a file `stats.json` and
periodically update it with stats. When the program is loaded the file
will be read if it exists.