### PR TITLE
Align 64-bit fields on structs to allow atomic access on 32-bit systems

### DIFF
--- a/pool/pool.go
+++ b/pool/pool.go
@@ -25,9 +25,9 @@ type Stratum struct {
 }
 
 type Port struct {
+	Difficulty int64  `json:"diff"`
 	Host       string `json:"host"`
 	Port       int    `json:"port"`
-	Difficulty int64  `json:"diff"`
 	MaxConn    int    `json:"maxConn"`
 }
 

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -32,19 +32,19 @@ type RPCClient struct {
 }
 
 type GetBlockTemplateReply struct {
-	Blob           string `json:"blocktemplate_blob"`
 	Difficulty     int64  `json:"difficulty"`
-	ReservedOffset int    `json:"reserved_offset"`
 	Height         int64  `json:"height"`
+	Blob           string `json:"blocktemplate_blob"`
+	ReservedOffset int    `json:"reserved_offset"`
 	PrevHash       string `json:"prev_hash"`
 }
 
 type GetInfoReply struct {
 	IncomingConnections int64  `json:"incoming_connections_count"`
 	OutgoingConnections int64  `json:"outgoing_connections_count"`
-	Status              string `json:"status"`
 	Height              int64  `json:"height"`
 	TxPoolSize          int64  `json:"tx_pool_size"`
+	Status              string `json:"status"`
 }
 
 type JSONRpcResp struct {

--- a/stratum/blocks.go
+++ b/stratum/blocks.go
@@ -11,9 +11,9 @@ import (
 )
 
 type BlockTemplate struct {
-	difficulty     *big.Int
 	diffInt64      int64
 	height         int64
+	difficulty     *big.Int
 	reservedOffset int
 	prevHash       string
 	buffer         []byte

--- a/stratum/miner.go
+++ b/stratum/miner.go
@@ -16,17 +16,14 @@ import (
 )
 
 type Job struct {
+	height      int64
 	sync.RWMutex
 	id          string
 	extraNonce  uint32
-	height      int64
 	submissions map[string]struct{}
 }
 
 type Miner struct {
-	sync.RWMutex
-	id            string
-	ip            string
 	lastBeat      int64
 	startedAt     int64
 	validShares   int64
@@ -35,6 +32,9 @@ type Miner struct {
 	accepts       int64
 	rejects       int64
 	shares        map[int64]int64
+	sync.RWMutex
+	id            string
+	ip            string
 }
 
 func (job *Job) submit(nonce string) bool {

--- a/stratum/stratum.go
+++ b/stratum/stratum.go
@@ -19,6 +19,10 @@ import (
 )
 
 type StratumServer struct {
+	luckWindow       int64
+	luckLargeWindow  int64
+	roundShares      int64
+	blockStats       map[int64]blockEntry
 	config           *pool.Config
 	miners           MinersMap
 	blockTemplate    atomic.Value
@@ -27,37 +31,33 @@ type StratumServer struct {
 	timeout          time.Duration
 	estimationWindow time.Duration
 	blocksMu         sync.RWMutex
-	blockStats       map[int64]blockEntry
-	luckWindow       int64
-	luckLargeWindow  int64
-	roundShares      int64
 	sessionsMu       sync.RWMutex
 	sessions         map[*Session]struct{}
 }
 
 type blockEntry struct {
 	height   int64
-	hash     string
 	variance float64
+	hash     string
 }
 
 type Endpoint struct {
+	jobSequence uint64
 	config      *pool.Port
 	difficulty  *big.Int
 	instanceId  []byte
 	extraNonce  uint32
 	targetHex   string
-	jobSequence uint64
 }
 
 type Session struct {
+	lastBlockHeight int64
 	sync.Mutex
 	conn            *net.TCPConn
 	enc             *json.Encoder
 	ip              string
 	endpoint        *Endpoint
 	validJobs       []*Job
-	lastBlockHeight int64
 }
 
 const (


### PR DESCRIPTION
This PR fixes monero-stratum in order to make it run on 32-bit systems.

As is, monero-stratum is not taking into account a [known bug in the Go atomic package](https://golang.org/src/sync/atomic/doc.go?s=1206:1668#L36):
>  On ARM, x86-32, and 32-bit MIPS, it is the caller's responsibility to arrange for 64-bit alignment of 64-bit words accessed atomically. The first word in a variable or in an allocated struct, array, or slice can be relied upon to be 64-bit aligned. 

When trying to run monero-stratum on both ARM and x86-32 I got several invalid memory accesses or nil pointer dereferences on the atomic operations. For instance:
```
panic: runtime error: index out of range
goroutine 25 [running]:
panic(0x806f10, 0x94722030)
	/usr/lib/go-1.7/src/runtime/panic.go:500 +0x33c
github.com/sammy007/monero-stratum/stratum.MinersMap.GetShard(0x94720700, 0x20, 0x20, 0x94770829, 0x8, 0x7ffa38)
	/home/dagon/monero-stratum/build/_workspace/src/github.com/sammy007/monero-stratum/stratum/mmap.go:34 +0xfc
```
```
sync/atomic.addUint64(0x947d88d4, 0x1f40, 0x0, 0x1f40, 0x0)
	/usr/lib/go-1.7/src/sync/atomic/64bit_arm.go:31 +0x68
github.com/sammy007/monero-stratum/stratum.(*Miner).processShare(0x948202a0, 0x947d8870, 0x9477ed50, 0x94822ba0, 0x94822600, 0x9481d780, 0x8, 0x94878840, 0x40, 0x16)
	/home/dagon/monero-stratum/build/_workspace/src/github.com/sammy007/monero-stratum/stratum/miner.go:203 +0x860
```

This PR puts all 64-bit fields at the top of each struct, making them compatible with atomic operations on all architectures supported by Go.