### PR TITLE
CryptonightR (Monero v0.14.0.0) compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,19 +18,19 @@ jobs:
           echo 'export PATH=~/go/bin:$PATH' >> ~/.bashrc
       - restore_cache:
           keys:
-            - v1-monero-{{ arch }}-v0.13.0.2.tar.gz
+            - v1-monero-{{ arch }}-v0.14.0.0.tar.gz
       - run: |
-          git clone --recursive --branch v0.13.0.2 https://github.com/monero-project/monero.git ~/monero-0.13.0.2
-          pushd ~/monero-0.13.0.2 && cmake -DBUILD_SHARED_LIBS=1 . && make && popd
+          git clone --recursive --branch v0.14.0.0 --depth 1 https://github.com/monero-project/monero.git ~/monero-0.14.0.0
+          pushd ~/monero-0.14.0.0 && cmake -DBUILD_SHARED_LIBS=1 . && make && popd
       - save_cache:
-          key: v1-monero-{{ arch }}-v0.13.0.2.tar.gz
+          key: v1-monero-{{ arch }}-v0.14.0.0.tar.gz
           paths:
-            - ~/monero-0.13.0.2
+            - ~/monero-0.14.0.0
       - checkout
       - run:
           name: Compile
           environment:
-            - MONERO_DIR: "~/monero-0.13.0.2"
+            - MONERO_DIR: "~/monero-0.14.0.0"
           command: |
             cmake .
             make

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Dependencies:
 
   * go-1.6
   * Everything required to build Monero
-  * Monero >= **v0.11.0.0** (sometimes `master` branch required)
+  * Monero >= **v0.14.0.0** (sometimes `master` branch required)
 
 ### Linux
 
@@ -34,7 +34,7 @@ Compile Monero source (with shared libraries option):
     apt-get install git cmake build-essential libssl-dev pkg-config libboost-all-dev
     git clone https://github.com/monero-project/monero.git
     cd monero
-    git checkout tags/v0.11.0.0 -b v0.11.0.0
+    git checkout tags/v0.14.0.0 -b v0.14.0.0
     cmake -DBUILD_SHARED_LIBS=1 .
     make
 
@@ -60,7 +60,7 @@ Compile Monero source:
 
     git clone https://github.com/monero-project/monero.git
     cd monero
-    git checkout tags/v0.11.0.0 -b v0.11.0.0
+    git checkout tags/v0.14.0.0 -b v0.14.0.0
     cmake .
     make
 

--- a/hashing/hashing.go
+++ b/hashing/hashing.go
@@ -8,16 +8,16 @@ package hashing
 import "C"
 import "unsafe"
 
-func Hash(blob []byte, fast bool) []byte {
+func Hash(blob []byte, fast bool, height int64) []byte {
 	output := make([]byte, 32)
 	if fast {
 		C.cryptonight_fast_hash((*C.char)(unsafe.Pointer(&blob[0])), (*C.char)(unsafe.Pointer(&output[0])), (C.uint32_t)(len(blob)))
 	} else {
-		C.cryptonight_hash((*C.char)(unsafe.Pointer(&blob[0])), (*C.char)(unsafe.Pointer(&output[0])), (C.uint32_t)(len(blob)))
+		C.cryptonight_hash((*C.char)(unsafe.Pointer(&blob[0])), (*C.char)(unsafe.Pointer(&output[0])), (C.uint32_t)(len(blob)), (C.uint64_t)(uint64(height)))
 	}
 	return output
 }
 
 func FastHash(blob []byte) []byte {
-	return Hash(append([]byte{byte(len(blob))}, blob...), true)
+	return Hash(append([]byte{byte(len(blob))}, blob...), true, 0)
 }

--- a/hashing/hashing_test.go
+++ b/hashing/hashing_test.go
@@ -5,12 +5,12 @@ import "log"
 import "encoding/hex"
 
 func TestHash(t *testing.T) {
-	blob, _ := hex.DecodeString("01009091e4aa05ff5fe4801727ed0c1b8b339e1a0054d75568fec6ba9c4346e88b10d59edbf6858b2b00008a63b2865b65b84d28bb31feb057b16a21e2eda4bf6cc6377e3310af04debe4a01")
-	hashBytes := Hash(blob, false)
+	blob, _ := hex.DecodeString("a1009091e4aa05ff5fe4801727ed0c1b8b339e1a0054d75568fec6ba9c4346e88b10d59edbf6858b2b00008a63b2865b65b84d28bb31feb057b16a21e2eda4bf6cc6377e3310af04debe4a01")
+	hashBytes := Hash(blob, false, 0)
 	hash := hex.EncodeToString(hashBytes)
 	log.Println(hash)
 
-	expectedHash := "a70a96f64a266f0f59e4f67c4a92f24fe8237c1349f377fd2720c9e1f2970400"
+	expectedHash := "9d38ea4c527970fee1c4f89272a6fb787de71fc95bba7592eaed6e20b7f7478e"
 
 	if hash != expectedHash {
 		t.Error("Invalid hash")
@@ -19,7 +19,7 @@ func TestHash(t *testing.T) {
 
 func TestHash_fast(t *testing.T) {
 	blob, _ := hex.DecodeString("01009091e4aa05ff5fe4801727ed0c1b8b339e1a0054d75568fec6ba9c4346e88b10d59edbf6858b2b00008a63b2865b65b84d28bb31feb057b16a21e2eda4bf6cc6377e3310af04debe4a01")
-	hashBytes := Hash(blob, true)
+	hashBytes := Hash(blob, true, 0)
 	hash := hex.EncodeToString(hashBytes)
 	log.Println(hash)
 
@@ -44,21 +44,21 @@ func TestFastHash(t *testing.T) {
 }
 
 func BenchmarkHash(b *testing.B) {
-	blob, _ := hex.DecodeString("0100b69bb3aa050a3106491f858f8646d3a8d13fd9924403bf07af95e6e7cc9e4ad105d76da27241565555866b1baa9db8f027cf57cd45d6835c11287b210d9ddb407deda565f8112e19e501")
+	blob, _ := hex.DecodeString("a100b69bb3aa050a3106491f858f8646d3a8d13fd9924403bf07af95e6e7cc9e4ad105d76da27241565555866b1baa9db8f027cf57cd45d6835c11287b210d9ddb407deda565f8112e19e501")
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		Hash(blob, false)
+		Hash(blob, false, 0)
 	}
 }
 
 func BenchmarkHashParallel(b *testing.B) {
-	blob, _ := hex.DecodeString("0100b69bb3aa050a3106491f858f8646d3a8d13fd9924403bf07af95e6e7cc9e4ad105d76da27241565555866b1baa9db8f027cf57cd45d6835c11287b210d9ddb407deda565f8112e19e501")
+	blob, _ := hex.DecodeString("a100b69bb3aa050a3106491f858f8646d3a8d13fd9924403bf07af95e6e7cc9e4ad105d76da27241565555866b1baa9db8f027cf57cd45d6835c11287b210d9ddb407deda565f8112e19e501")
 	b.ResetTimer()
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			Hash(blob, false)
+			Hash(blob, false, 0)
 		}
 	})
 }
@@ -68,7 +68,7 @@ func BenchmarkHash_fast(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		Hash(blob, true)
+		Hash(blob, true, 0)
 	}
 }
 

--- a/hashing/src/hashing.c
+++ b/hashing/src/hashing.c
@@ -1,8 +1,8 @@
 #include "crypto/hash-ops.h"
 
-void cryptonight_hash(const char* input, char* output, uint32_t len) {
+void cryptonight_hash(const char* input, char* output, uint32_t len, uint64_t height) {
     const int variant = input[0] >= 7 ? input[0] - 6 : 0;
-    cn_slow_hash(input, len, output, variant, 0);
+    cn_slow_hash(input, len, output, variant, 0, height);
 }
 
 void cryptonight_fast_hash(const char* input, char* output, uint32_t len) {

--- a/hashing/src/hashing.h
+++ b/hashing/src/hashing.h
@@ -1,2 +1,2 @@
-void cryptonight_hash(const char* input, char* output, uint32_t len);
+void cryptonight_hash(const char* input, char* output, uint32_t len, uint64_t height);
 void cryptonight_fast_hash(const char* input, char* output, uint32_t len);

--- a/stratum/miner.go
+++ b/stratum/miner.go
@@ -152,7 +152,7 @@ func (m *Miner) processShare(s *StratumServer, cs *Session, job *Job, t *BlockTe
 		hashBytes, _ = hex.DecodeString(result)
 	} else {
 		convertedBlob = cnutil.ConvertBlob(shareBuff)
-		hashBytes = hashing.Hash(convertedBlob, false)
+		hashBytes = hashing.Hash(convertedBlob, false, t.height)
 	}
 
 	if !s.config.BypassShareValidation && hex.EncodeToString(hashBytes) != result {


### PR DESCRIPTION
This PR allows monero-stratum to be built with Monero `v0.14.0.0`.

Monero `v0.14.0.0` requires the block height as argument in `cn_slow_hash`. This is mandatory for the hardfork that will take place at block 1788000 (March 9th).  The hardfork will increase the block `major_version` to `10` and implement a new PoW algorithm (CryptonightR, aka CryptoNight variant 4).

Summary for this PR:
- Adds block height as argument in all calls to the slow hash.
- Updates hashing tests to use a block blob with `major_version=10`.
- Mentions `v0.14.0.0` as minimum Monero version in README.
- Updates circle-ci for `v0.14.0.0`.